### PR TITLE
[CLOUD-506] Allow nginx install to be disabled

### DIFF
--- a/roles/nginx/defaults/main.yml
+++ b/roles/nginx/defaults/main.yml
@@ -1,4 +1,6 @@
 ---
+# var to short circuit the entire role
+nginx_enabled: true
 
 # Nginx Settings
 

--- a/roles/nginx/tasks/main.yml
+++ b/roles/nginx/tasks/main.yml
@@ -1,4 +1,7 @@
 ---
 - include: install.yml
+  when: nginx_enabled == true
 - include: configure.yml
+  when: nginx_enabled == true
 - include: sites.yml
+  when: nginx_enabled == true


### PR DESCRIPTION
This will be a no-op for most, but it adds functionality useful when including roles that themselves wrap nginx.  