### PR TITLE
External templates

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,38 @@
+ansible-role-nginx
+====================
+
+A role to install nginx and configure 0 or more sites' doc roots and nginx config files.
+
+An example might be:
+
+<pre>
+nginx_sites:
+  - name: testsite
+    template: site.j2
+    files:
+    - name: up.json
+      content: '{ "status": "happy" }'    
+</pre>
+
+With a `site.j2` such as: 
+
+<pre>
+server {
+  listen 81;
+  server_name {{item.name}};
+  access_log /var/log/nginx/81.log;
+  location /404 {
+    return 404;
+  }
+  location ~ ^/up/?$ {
+    root /var/www/{{item.name}};
+    rewrite ^.*$ /up.json break;
+  }
+  location / {
+    return 204;
+  }
+}
+</pre>
+
+A docroot '/var/www/testsite' will be created holding `up.json` with the 
+specified content.  The config in `site.j2` will be used for the site.  There is a stub config in `roles/nginx/templates/` that can be used, but it's unliekly to support the exact configuration you need, which is why using an external template is supported.  

--- a/inventory/group_vars/vagrant
+++ b/inventory/group_vars/vagrant
@@ -1,0 +1,8 @@
+---
+#:vim: ft=yml
+nginx_sites:
+  - name: testsite
+    template: site.j2
+    files:
+    - name: up.json
+      content: '{ "status": "happy" }'    

--- a/roles/nginx/tasks/sites.yml
+++ b/roles/nginx/tasks/sites.yml
@@ -1,17 +1,17 @@
 - name: nginx site root
-  file: > 
-    state=directory path={{nginx_sites_path}}/{{item.name}} 
-    owner=root  
-    mode=0755 
+  file: >
+    state=directory path={{nginx_sites_path}}/{{item.name}}
+    owner=root
+    mode=0755
   # note: we should determine nginx group as well
   with_items: nginx_sites
   notify: restart nginx
 
-- name: nginx site 
-  template: src="{{ item.template | default('site.conf.j2') }}  
+- name: nginx site
+  template: src="{{ item.template | default('site.conf.j2') }}"
   args:
     dest: /etc/nginx/sites-available/{{ item.name }}
-    mode: 0644 
+    mode: 0644
     owner: root
   with_items: nginx_sites
   notify: restart nginx

--- a/roles/nginx/tasks/sites.yml
+++ b/roles/nginx/tasks/sites.yml
@@ -8,7 +8,7 @@
   notify: restart nginx
 
 - name: nginx site 
-  template: src=site.conf.j2  
+  template: src="{{ item.template | default('site.conf.j2') }}  
   args:
     dest: /etc/nginx/sites-available/{{ item.name }}
     mode: 0644 

--- a/site.j2
+++ b/site.j2
@@ -1,0 +1,16 @@
+server {
+  listen 81;
+  server_name {{item.name}};
+  access_log /var/log/nginx/81.log;
+  location /404 {
+    return 404;
+  }
+  location ~ ^/up/?$ {
+    root /var/www/{{item.name}};
+    rewrite ^.*$ /up.json break;
+  }
+  location / {
+    return 204;
+  }
+}
+

--- a/tests.yml
+++ b/tests.yml
@@ -1,13 +1,23 @@
 - hosts: nginx
   tasks:
-    - command: "curl -s -H 'Host: {{item.0.name}}' 'http://127.0.0.1/{{item.1.name}}'"
+    - command: "curl -v -H 'Host: testsite' 'http://127.0.0.1:81/up'"
       register: curlresponse
-      with_subelements: 
-        - nginx_sites
-        - files
-      changed_when: false
-    - debug: var=item.stdout
-      with_items: curlresponse.results
-    - fail: Failed to pull expected example website content
-      when: "item.stdout != '<div style=\\'text-align: center\\'>\nExample Website\n</div>'"
-      with_items: curlresponse.results
+    - assert: 
+        that:
+          - curlresponse.rc == 0
+          - '"200" in curlresponse.stderr'
+          - '"happy" in curlresponse.stdout'
+
+    - command: "curl -v -H 'Host: testsite' 'http://127.0.0.1:81/404'"
+      register: curlresponse
+    - assert: 
+        that:
+          - curlresponse.rc == 0
+          - '"404" in curlresponse.stderr'
+
+    - command: "curl -v -H 'Host: testsite' 'http://127.0.0.1:81/other'"
+      register: curlresponse
+    - assert: 
+        that:
+          - curlresponse.rc == 0
+          - '"204" in curlresponse.stderr'


### PR DESCRIPTION
* Support external templates in the sites list 
  - allows the role to handle arbitrary config and still handle available/enabled site links 
* added testing config for such a site which is tested with a `rake` 
* added a readme