### PR TITLE
Update default version for ppa repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ A role to install nginx and configure 0 or more sites' doc roots and nginx confi
 
 For ubuntu systems, it is possible to install the PPA rather than the standard package-managed
 version. This can be done by specifying install_ppa: True in the playbook. To specify a version 
-of nginx to install, use the nginx_version variable. The default is 1.8.0-1+trusty1. 
+of nginx to install, use the nginx_version variable. The default is 1.8.1-1+trusty0. 
 
 An example might be:
 

--- a/tasks/install-ppa.yml
+++ b/tasks/install-ppa.yml
@@ -5,7 +5,7 @@
 
 - name: Install nginx
   apt:
-    name: "nginx={{ nginx_version | default('1.8.0-1+trusty1') }}"
+    name: "nginx={{ nginx_version | default('1.8.1-1+trusty0') }}"
     state: present
     update_cache: yes
   notify: restart nginx


### PR DESCRIPTION
The default version no longer exists. Updated Jan 27 2016 https://launchpad.net/~nginx/+archive/ubuntu/stable/+packages