### PR TITLE
Switch restart handler to use the command module

### DIFF
--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -1,5 +1,11 @@
 ---
+#- name: restart nginx
+#  service:
+#    name: nginx
+#    state: restarted
+
+# https://github.com/ansible/ansible/issues/9108
+# https://github.com/SPSCommerce/ansible-role-nginx/issues/1
+
 - name: restart nginx
-  service:
-    name: nginx
-    state: restarted
+  command: service nginx restart


### PR DESCRIPTION
It actually seems to work reliably, and fail on syntax errors.

Addresses: https://github.com/SPSCommerce/ansible-role-nginx/issues/1

@danrue @farrellit 