### PR TITLE
Always update cache

### DIFF
--- a/meta/main.yml
+++ b/meta/main.yml
@@ -4,7 +4,7 @@ galaxy_info:
   description: A role to install nginx and configure 0 or more sites doc roots and nginx config files.
   company: SPS Commerce
   license: 
-  min_ansible_version: 1.8
+  min_ansible_version: 1.9
   platforms:
   - name: Ubuntu
     versions:

--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -3,6 +3,7 @@
   yum:
     name: epel-release
     state: present
+    update_cache: true
   when: ansible_pkg_mgr == 'yum'
   register: installed
   until: installed|success
@@ -13,6 +14,7 @@
   action:
     module: "{{ ansible_pkg_mgr }}" 
     name: "{{ item }}"
+    update_cache: true
   when: ansible_os_family in nginx_ancillary_packages.keys()
   with_items: nginx_ancillary_packages[ansible_os_family]|default([])
   register: installed

--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -25,6 +25,7 @@
     module: "{{ ansible_pkg_mgr }}"
     name: nginx
     state: present
+    update_cache: true
   register: installed
   until: installed|success
   retries: 5


### PR DESCRIPTION
Just ran into an issue where nginx failed to install due to stale cache.
I don't think we can punt on this; if nothing ever updates the apt
cache, this role *will* fail eventually.