### PR TITLE
Remove empty list variable, nginx_sites

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -17,7 +17,6 @@ nginx_gzip_comp_level: 6
 nginx_sendfile: true
 nginx_keepalive_timeout: 7
 nginx_access_log_format: combined
-nginx_sites: []
 nginx_sites_path: /var/www
 
 # Ancillary

--- a/tasks/sites.yml
+++ b/tasks/sites.yml
@@ -6,6 +6,7 @@
     mode: 0755
     # Note: we should determine nginx group as well
   with_items: nginx_sites
+  when: nginx_sites is defined
   notify: restart nginx
 
 - name: Create nginx site from template
@@ -15,6 +16,7 @@
     mode: 0644
     owner: root
   with_items: nginx_sites
+  when: nginx_sites is defined
   notify: restart nginx
 
 - name: Create nginx site from files
@@ -24,7 +26,7 @@
     owner: root
     mode: 0644
   with_subelements:
-    - "{{ nginx_sites | selectattr('files', 'defined') | list }}"  # http://stackoverflow.com/a/31145937
+    - "{{ nginx_sites|default('') | selectattr('files', 'defined') | list }}"  # http://stackoverflow.com/a/31145937
     - "files"                                                      # skip_missing flag only seems to exist in Ansible >= 2.0 https://github.com/ansible/ansible/issues/9827#issuecomment-196806299
   notify: restart nginx
 
@@ -34,3 +36,4 @@
     src: "{{ nginx_sites_available }}/{{ item.name }}"
     dest: "{{ nginx_sites_enabled }}/{{ item.name }}"
   with_items: nginx_sites
+  when: nginx_sites is defined


### PR DESCRIPTION
With ansible-2.2.0.0 I was receiving the following error:

```
TASK [nginx : Create nginx site root] ******************************************
fatal: [localhost]: FAILED! => {"failed": true, "msg": "the field 'args' has an invalid value, which appears to include a variable that is undefined. The error was: 'unicode object' has no attribute 'name'\n\nThe error appears to have been in '/opt/ansible/roles/nginx/tasks/sites.yml': line 1, column 3, but may\nbe elsewhere in the file depending on the exact syntax problem.\n\nThe offending line appears to be:\n\n\n- name: Create nginx site root\n  ^ here\n"}
```

This patch fixes that in my testing scenario.