### PR TITLE
Use full jinja2 variable expansion in with_items for Ansible 2 support

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -17,6 +17,7 @@ nginx_gzip_comp_level: 6
 nginx_sendfile: true
 nginx_keepalive_timeout: 7
 nginx_access_log_format: combined
+nginx_sites: []
 nginx_sites_path: /var/www
 
 # Ancillary

--- a/tasks/sites.yml
+++ b/tasks/sites.yml
@@ -5,8 +5,7 @@
     owner: root
     mode: 0755
     # Note: we should determine nginx group as well
-  with_items: nginx_sites
-  when: nginx_sites is defined
+  with_items: "{{ nginx_sites }}"
   notify: restart nginx
 
 - name: Create nginx site from template
@@ -15,8 +14,7 @@
     dest: "{{ nginx_sites_available }}/{{ item.name }}"
     mode: 0644
     owner: root
-  with_items: nginx_sites
-  when: nginx_sites is defined
+  with_items: "{{ nginx_sites }}"
   notify: restart nginx
 
 - name: Create nginx site from files
@@ -26,7 +24,7 @@
     owner: root
     mode: 0644
   with_subelements:
-    - "{{ nginx_sites|default('') | selectattr('files', 'defined') | list }}"  # http://stackoverflow.com/a/31145937
+    - "{{ nginx_sites | selectattr('files', 'defined') | list }}"  # http://stackoverflow.com/a/31145937
     - "files"                                                      # skip_missing flag only seems to exist in Ansible >= 2.0 https://github.com/ansible/ansible/issues/9827#issuecomment-196806299
   notify: restart nginx
 
@@ -35,5 +33,4 @@
     state: link
     src: "{{ nginx_sites_available }}/{{ item.name }}"
     dest: "{{ nginx_sites_enabled }}/{{ item.name }}"
-  with_items: nginx_sites
-  when: nginx_sites is defined
+  with_items: "{{ nginx_sites }}"


### PR DESCRIPTION
Reverts and addresses same problem as: https://github.com/SPSCommerce/ansible-role-nginx/pull/12